### PR TITLE
add titiler example

### DIFF
--- a/examples/titiler/docker-compose.yaml
+++ b/examples/titiler/docker-compose.yaml
@@ -14,14 +14,14 @@ services:
       # https://github.com/tiangolo/uvicorn-gunicorn-docker#workers_per_core
       WORKERS_PER_CORE: 1
       # GDAL config
-      # CPL_TMPDIR: /tmp
-      # GDAL_CACHEMAX: 75%
-      # GDAL_INGESTED_BYTES_AT_OPEN: 32768
-      # GDAL_DISABLE_READDIR_ON_OPEN: FALSE
-      # GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: YES
-      # PYTHONWARNINGS: ignore
-      # VSI_CACHE: TRUE
-      # VSI_CACHE_SIZE: 536870912
+      CPL_TMPDIR: /tmp
+      GDAL_CACHEMAX: 75%
+      GDAL_INGESTED_BYTES_AT_OPEN: 32768
+      GDAL_DISABLE_READDIR_ON_OPEN: EMPTY_DIR
+      GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: YES
+      PYTHONWARNINGS: ignore
+      VSI_CACHE: TRUE
+      VSI_CACHE_SIZE: 536870912
   nginx:
       image: nginx:latest
       volumes:

--- a/examples/titiler/docker-compose.yaml
+++ b/examples/titiler/docker-compose.yaml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  titiler:
+    hostname: titiler
+    image: developmentseed/titiler
+    ports:
+      - 5000
+    environment:
+      PORT: 5000
+      # Gunicorn / Uvicorn
+      # https://github.com/tiangolo/uvicorn-gunicorn-docker#web_concurrency
+      WEB_CONCURRENCY: 1
+      # https://github.com/tiangolo/uvicorn-gunicorn-docker#workers_per_core
+      WORKERS_PER_CORE: 1
+      # GDAL config
+      # CPL_TMPDIR: /tmp
+      # GDAL_CACHEMAX: 75%
+      # GDAL_INGESTED_BYTES_AT_OPEN: 32768
+      # GDAL_DISABLE_READDIR_ON_OPEN: FALSE
+      # GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: YES
+      # PYTHONWARNINGS: ignore
+      # VSI_CACHE: TRUE
+      # VSI_CACHE_SIZE: 536870912
+  nginx:
+      image: nginx:latest
+      volumes:
+        - ./nginx/default.conf:/etc/nginx/nginx.conf:ro
+      depends_on:
+        - titiler
+      ports:
+        - "4000:4000"

--- a/examples/titiler/dump_tiles.py
+++ b/examples/titiler/dump_tiles.py
@@ -1,0 +1,74 @@
+"""Dump all tiles from an image via titiler"""
+import asyncio
+import os
+from functools import wraps
+from urllib.parse import urljoin
+
+import aiohttp
+import click
+import mercantile
+
+TITILER_BASE_URL = os.getenv("TITILER_BASE_URL", "http://localhost:4000")
+TITILER_INFO_ENDPOINT = urljoin(TITILER_BASE_URL, "/cog/info")
+TITILER_TILE_ENDPOINT = urljoin(TITILER_BASE_URL, "/cog/tiles/{z}/{x}/{y}")
+
+
+async def _fetch_info(session: aiohttp.ClientSession, infile: str):
+    params = {"url": infile}
+    async with session.get(TITILER_INFO_ENDPOINT, params=params) as resp:
+        resp.raise_for_status()
+        return await resp.json()
+
+
+async def _fetch_tile(session: aiohttp.ClientSession, tile: mercantile.Tile, infile: str):
+    tile_url = TITILER_TILE_ENDPOINT.format(x=tile.x, y=tile.y, z=tile.z)
+    params = {"url": infile}
+    async with session.get(tile_url, params=params) as resp:
+        if resp.status == 404:
+            return
+        resp.raise_for_status()
+        return await resp.read()
+
+
+async def _fetch_tile_semaphore(session: aiohttp.ClientSession, tile: mercantile.Tile, infile: str, semaphore: asyncio.Semaphore):
+    async with semaphore:
+        await _fetch_tile(session, tile, infile)
+
+
+async def dump_tiles(infile: str, minzoom: int = None, maxzoom: int = None, limit: int = None, concurrency: int = 50):
+    """Dump all tiles from the infil between min and max zoom."""
+    async with aiohttp.ClientSession() as session:
+        cog_info = await _fetch_info(session, infile)
+
+        minzoom = minzoom or cog_info['minzoom']
+        maxzoom = maxzoom or cog_info['maxzoom']
+        tiles = mercantile.tiles(*cog_info['bounds'], range(minzoom, maxzoom + 1))
+        if limit:
+            tiles = list(tiles)[:limit]
+
+        semaphore = asyncio.Semaphore(concurrency)
+        await asyncio.gather(
+            *[_fetch_tile_semaphore(session, tile, infile, semaphore) for tile in tiles]
+        )  
+
+
+def coro(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(f(*args, **kwargs))
+    return wrapper
+
+
+@click.command()
+@click.argument("infile")
+@click.option("--minzoom", type=int, default=None)
+@click.option("--maxzoom", type=int, default=None)
+@click.option("--limit", type=int, default=None)
+@click.option("--concurrency", type=int, default=50)
+@coro
+async def main(infile: str, minzoom: int = None, maxzoom: int = None, limit: int = None, concurrency: int = 50):
+    await dump_tiles(infile, minzoom, maxzoom, limit, concurrency)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/titiler/dump_tiles.py
+++ b/examples/titiler/dump_tiles.py
@@ -1,9 +1,13 @@
 """Dump all tiles from an image via titiler"""
+
 import asyncio
 import os
+from datetime import datetime
 from functools import wraps
 from urllib.parse import urljoin
 
+import aiofiles
+import aiocsv
 import aiohttp
 import click
 import mercantile
@@ -11,6 +15,35 @@ import mercantile
 TITILER_BASE_URL = os.getenv("TITILER_BASE_URL", "http://localhost:4000")
 TITILER_INFO_ENDPOINT = urljoin(TITILER_BASE_URL, "/cog/info")
 TITILER_TILE_ENDPOINT = urljoin(TITILER_BASE_URL, "/cog/tiles/{z}/{x}/{y}")
+
+
+def _create_aiohttp_tracer(writer: aiocsv.AsyncWriter) -> aiohttp.TraceConfig:
+    """Create aiohttp session that writes out metadata for each request to a CSV file."""
+
+    async def _on_request_start(session, trace_config_ctx, params):
+        # Using event loop for measuring request duration because it's more accurate than `datetime` here
+        trace_config_ctx.start_time = asyncio.get_event_loop().time()
+        trace_config_ctx.request_start_time = datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    async def _on_request_end(session, trace_config_ctx, params):
+        duration_seconds = asyncio.get_event_loop().time() - trace_config_ctx.start_time
+        http_path = params.url.path
+        image_url = params.url.query["url"]
+
+        # Write out to csv
+        await writer.writerow(
+            [
+                http_path,
+                duration_seconds,
+                trace_config_ctx.request_start_time,
+                image_url,
+            ]
+        )
+
+    trace_config = aiohttp.TraceConfig()
+    trace_config.on_request_start.append(_on_request_start)
+    trace_config.on_request_end.append(_on_request_end)
+    return trace_config
 
 
 async def _fetch_info(session: aiohttp.ClientSession, infile: str):
@@ -30,44 +63,72 @@ async def _fetch_tile(session: aiohttp.ClientSession, tile: mercantile.Tile, inf
         return await resp.read()
 
 
-async def _fetch_tile_semaphore(session: aiohttp.ClientSession, tile: mercantile.Tile, infile: str, semaphore: asyncio.Semaphore):
+async def _fetch_tile_semaphore(
+    session: aiohttp.ClientSession,
+    tile: mercantile.Tile,
+    infile: str,
+    semaphore: asyncio.Semaphore,
+):
     async with semaphore:
         await _fetch_tile(session, tile, infile)
 
 
-async def dump_tiles(infile: str, minzoom: int = None, maxzoom: int = None, limit: int = None, concurrency: int = 50):
+async def dump_tiles(
+    session: aiohttp.ClientSession,
+    infile: str,
+    minzoom: int = None,
+    maxzoom: int = None,
+    limit: int = None,
+    concurrency: int = 50,
+):
     """Dump all tiles from the infil between min and max zoom."""
-    async with aiohttp.ClientSession() as session:
-        cog_info = await _fetch_info(session, infile)
+    cog_info = await _fetch_info(session, infile)
 
-        minzoom = minzoom or cog_info['minzoom']
-        maxzoom = maxzoom or cog_info['maxzoom']
-        tiles = mercantile.tiles(*cog_info['bounds'], range(minzoom, maxzoom + 1))
-        if limit:
-            tiles = list(tiles)[:limit]
+    minzoom = minzoom or cog_info["minzoom"]
+    maxzoom = maxzoom or cog_info["maxzoom"]
+    tiles = mercantile.tiles(*cog_info["bounds"], range(minzoom, maxzoom + 1))
+    if limit:
+        tiles = list(tiles)[:limit]
 
-        semaphore = asyncio.Semaphore(concurrency)
-        await asyncio.gather(
-            *[_fetch_tile_semaphore(session, tile, infile, semaphore) for tile in tiles]
-        )  
+    semaphore = asyncio.Semaphore(concurrency)
+    await asyncio.gather(
+        *[_fetch_tile_semaphore(session, tile, infile, semaphore) for tile in tiles]
+    )
 
 
 def coro(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
         return asyncio.run(f(*args, **kwargs))
+
     return wrapper
 
 
 @click.command()
 @click.argument("infile")
+@click.argument("outfile")
 @click.option("--minzoom", type=int, default=None)
 @click.option("--maxzoom", type=int, default=None)
 @click.option("--limit", type=int, default=None)
 @click.option("--concurrency", type=int, default=50)
 @coro
-async def main(infile: str, minzoom: int = None, maxzoom: int = None, limit: int = None, concurrency: int = 50):
-    await dump_tiles(infile, minzoom, maxzoom, limit, concurrency)
+async def main(
+    infile: str,
+    outfile: str,
+    minzoom: int = None,
+    maxzoom: int = None,
+    limit: int = None,
+    concurrency: int = 50,
+):
+    assert outfile.endswith(".csv")
+
+    async with aiofiles.open(outfile, "w") as outf:
+        writer = aiocsv.AsyncWriter(outf)
+        await writer.writerow(["http_path", "duration_seconds", "start_time", "url"])
+
+        trace_config = _create_aiohttp_tracer(writer)
+        async with aiohttp.ClientSession(trace_configs=[trace_config]) as session:
+            await dump_tiles(session, infile, minzoom, maxzoom, limit, concurrency)
 
 
 if __name__ == "__main__":

--- a/examples/titiler/nginx/default.conf
+++ b/examples/titiler/nginx/default.conf
@@ -1,0 +1,12 @@
+user  nginx;
+events {
+    worker_connections   1000;
+}
+http {
+        server {
+              listen 4000;
+              location / {
+                proxy_pass http://titiler:5000;
+              }
+        }
+}

--- a/examples/titiler/requirements.txt
+++ b/examples/titiler/requirements.txt
@@ -1,3 +1,5 @@
 mercantile==1.2.1
 aiohttp==3.9.5
 click==8.1.7
+aiofiles==24.1.0
+aiocsv==1.3.2

--- a/examples/titiler/requirements.txt
+++ b/examples/titiler/requirements.txt
@@ -1,0 +1,3 @@
+mercantile==1.2.1
+aiohttp==3.9.5
+click==8.1.7


### PR DESCRIPTION
Adds a titiler docker-compose stack and a `dump_tiles.py` script for benchmarking titiler performance with and without the proxy.

Setup the docker-compose stack at the root of the repo:
```shell
docker compose up --build
```

Then the titiler stack:
```shell
cd examples/titiler
docker compose up --build
```

Then use `dump_tiles.py` to test:

```shell
pip install -r requirements.txt
python dump_tiles.py http://sentinel-cogs.s3.amazonaws.com/sentinel-s2-l2a-cogs/57/C/VK/2019/11/S2B_57CVK_20191122_0_L2A/B04.tif metrics.csv --concurrency 5 --limit 100
```

Results are saved to a local CSV file:
```shell
> head -n 2 metrics.csv
http_path,duration_seconds,start_time,url
/cog/info,0.12747733300784603,2024-07-07T14:10:15.383554Z,http://host.docker.internal:8000/sentinel-s2-l2a-cogs/57/C/VK/2019/11/S2B_57CVK_20191122_0_L2A/B04.tif
```



Call through the proxy by replacing the hostname `sentinel-cogs.s3.amazonaws.com` with `host.docker.internal:8000`.  Should work for any image in the `sentinel-cogs` S3 bucket.