### PR TITLE
Support vsis3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,28 @@ Deploy the proxy with three peers and an NGINX server (`:8000`) load balancing a
 docker compose up --build
 ```
 
-Send a `gdalinfo` call to a publicly available S2 image through the proxy.  The second time running this command should be much faster than the first because the initial HTTP range request to fetch the COG header is cached by the proxy.
+Send a `gdalinfo` call to a publicly available S2 image through the proxy using `/vsicurl`.  The second time running this command should be much faster than the first because the initial HTTP range request to fetch the COG header is cached by the proxy.
 ```
 CPL_CURL_VERBOSE=YES \
 GDAL_DISABLE_READDIR_ON_OPEN=TRUE \
 CPL_VSIL_CURL_ALLOWED_EXTENSIONS=.tif \
-gdalinfo /vsicurl/http://localhost:8000/sentinel-s2-l2a-cogs/57/C/VK/2019/11/S2B_57CVK_20191122_0_L2A/B04.tif
+GDAL_HTTP_PROXY=localhost:8000 \
+gdalinfo /vsicurl/http://sentinel-cogs.s3.amazonaws.com/sentinel-s2-l2a-cogs/57/C/VK/2019/11/S2B_57CVK_20191122_0_L2A/B04.tif
+```
+
+For data in S3 that requires authentication (e.g. private buckets or public "requestor pays" buckets) use `/vsis3`:
+
+``` 
+CPL_CURL_VERBOSE=YES \
+GDAL_DISABLE_READDIR_ON_OPEN=TRUE \
+CPL_VSIL_CURL_ALLOWED_EXTENSIONS=.tif \
+AWS_HTTPS=no \
+AWS_REQUEST_PAYER=requester \
+GDAL_HTTP_PROXY=localhost:8000 \
+gdalinfo /vsis3/usgs-landsat/collection02/level-2/standard/oli-tirs/2025/086/075/LC09_L2SR_086075_20250501_20250502_02_T2/LC09_L2SR_086075_20250501_20250502_02_T2_SR_B2.TIF
 ```
 
 ## Limitations
-- `/vsicurl` only, does not support `/vsis3` or `/vsigs` (which requires HMAC key signing).
+- `/vsicurl` and `/viss3` only, `/vsigs` and `/vsiaz` not yet supported.
 - Does not honor or forward `X-Forwarded-*` headers.
 - No HTTPS on inbound requests.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      PROXY_HOSTNAME: "sentinel-cogs.s3.amazonaws.com"
       GROUPCACHE_PEERS: "http://app1:8080,http://app2:8080,http://app3:8080"
+      STRIP_HEADERS: "Authorization,X-Amz-Date"
   app2:
     build:
       context: .
@@ -18,8 +18,8 @@ services:
     ports:
       - "8081:8080"
     environment:
-      PROXY_HOSTNAME: "sentinel-cogs.s3.amazonaws.com"
       GROUPCACHE_PEERS: "http://app2:8080,http://app1:8080,http://app3:8080"
+      STRIP_HEADERS: "Authorization,X-Amz-Date"
   app3:
     build:
       context: .
@@ -28,8 +28,8 @@ services:
     ports:
       - "8082:8080"
     environment:
-      PROXY_HOSTNAME: "sentinel-cogs.s3.amazonaws.com"
       GROUPCACHE_PEERS: "http://app3:8080,http://app1:8080,http://app2:8080"
+      STRIP_HEADERS: "Authorization,X-Amz-Date"
   nginx:
     image: nginx
     ports:

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"bytes"
@@ -25,16 +26,39 @@ func copyHeader(dst, src http.Header) {
 	}
 }
 
-func proxyHandler(w http.ResponseWriter, r *http.Request) {
-	// Serialize request to string (cache key)
-	var b = &bytes.Buffer{}
-	if err := r.Write(b); err != nil {
-		log.Fatal(err)
+
+type ProxyHandler struct {
+	stripHeaders []string
+}
+
+
+func (p ProxyHandler) GetKey(r http.Request) string {
+    // Ensure we don't modify the headers on the original request
+	copiedHeaders := make(http.Header, len(r.Header))
+    for k, v := range r.Header {
+        copiedHeaders[k] = append([]string(nil), v...)
+    }
+
+    r.Header = copiedHeaders
+    for _, header := range p.stripHeaders {
+        r.Header.Del(header)
+    }
+
+	key, err := httputil.DumpRequest(&r, true)
+	if err != nil {
+		panic(err)
 	}
+
+	return string(key)
+}
+
+func (p ProxyHandler) Handle (w http.ResponseWriter, r *http.Request) {
+	// Serialize request to string (cache key)
+	key := p.GetKey(*r)
 
 	// Hit the cache
 	var data []byte
-	if err := group.Get(r.Context(), b.String(), groupcache.AllocatingByteSliceSink(&data)); err != nil {
+	if err := group.Get(context.WithValue(r.Context(), "request", r), key, groupcache.AllocatingByteSliceSink(&data)); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -51,7 +75,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(res.StatusCode)
 	io.Copy(w, res.Body)
 	res.Body.Close()
-}	
+}
 
 func newPool(peers []string) *groupcache.HTTPPool {
 	pool := groupcache.NewHTTPPoolOpts(peers[0], nil)
@@ -62,43 +86,36 @@ func newPool(peers []string) *groupcache.HTTPPool {
 
 var group *groupcache.Group
 
-func newGroup(hostName string, cacheSizeBytes int64) {
+func newGroup(cacheSizeBytes int64) {
 	group = groupcache.NewGroup("requests", cacheSizeBytes, groupcache.GetterFunc(
-		func(_ context.Context, key string, sink groupcache.Sink) error {
+		func(ctx context.Context, key string, sink groupcache.Sink) error {
 			me, err := os.Hostname()
 			if err != nil {
 				log.Panic(err)
 			}
-	
+
 			log.Printf("Request handled by %s", me)
-	
-			// Rebuild HTTP request from cache key
-			reader := bufio.NewReader(strings.NewReader(key))
-			originalRequest, err := http.ReadRequest(reader)
-			if err != nil {
-				log.Panic(err)
+
+			// Get original request from context
+			r, ok := ctx.Value("request").(*http.Request)
+			if !ok {
+				log.Panic("Can't get original request from context")
 			}
-	
+
 			// We can't have this set on client requests
-			originalRequest.RequestURI = ""
-	
-			rawURL := "http://" + hostName
-			if originalRequest.URL.Path != "" {
-				rawURL = rawURL + originalRequest.URL.Path
-			}
-			fullUrl, err := url.Parse(rawURL)
+			r.RequestURI = ""
+			// Server requests only have the path in the URL, but client requests need the scheme + host too
+			r.URL, err= url.Parse("https://" + r.Host + r.URL.Path)
 			if err != nil {
 				log.Panic(err)
 			}
-			originalRequest.URL = fullUrl
-			originalRequest.Host = hostName
-	
+
 			client := http.Client{}
-			res, err := client.Do(originalRequest)
+ 			res, err := client.Do(r)
 			if err != nil {
 				log.Panic(err)
 			}
-	
+
 			// Write HTTP response out to bytes, store in cache
 			var outBuf bytes.Buffer
 			if err := res.Write(&outBuf); err != nil {
@@ -107,7 +124,7 @@ func newGroup(hostName string, cacheSizeBytes int64) {
 			sink.SetBytes(outBuf.Bytes(), time.Time{})
 			return nil
 		},
-	))	
+	))
 }
 
 
@@ -118,27 +135,24 @@ func main() {
 	// Default to 50mb cache
 	config.SetDefault("GROUPCACHE_SIZE_BYTES", 50000000)
 
-	proxyHostname := config.GetString("PROXY_HOSTNAME")
+	stripHeaders := config.GetString("STRIP_HEADERS")
 	cachePeers := config.GetString("GROUPCACHE_PEERS")
 	cacheSizeBytes := config.GetInt64("GROUPCACHE_SIZE_BYTES")
-	if proxyHostname == "" {
-		log.Fatal("Missing required env variable PROXY_HOSTNAME")
-	}
 	if cachePeers == "" {
 		log.Fatal("Missing required env variable GROUPCACHE_PEERS")
 	}
 
-
-
 	// Setup groupcache
-	newGroup(proxyHostname, cacheSizeBytes)
+	newGroup(cacheSizeBytes)
 	peersList := strings.Split(cachePeers, ",")
-	
 
 	log.Printf("listening on %v", peersList[0])
 	log.Printf("peers: %v", peersList)
 
-	http.HandleFunc("/", http.HandlerFunc(proxyHandler))
+	p := ProxyHandler{
+		stripHeaders: strings.Split(stripHeaders, ","),
+	} 
+	http.HandleFunc("/", http.HandlerFunc(p.Handle))
 	http.Handle("/_groupcache/", newPool(peersList))
 
 	log.Fatal(http.ListenAndServe(":8080", nil))


### PR DESCRIPTION
PR for #9 

Removes the `PROXY_HOSTNAME` configuration option and the associated code for modifying the `Host` header.

Adds a new `STRIP_HEADERS` configuration option for headers that need to be removed before hashing the request to generate consistent cash key. For S3 these are `Authorization` and `X-Amz-Date`, but wanted to make it easy to add others with an eye for adding support for `/vsigs` and/or `/vsiaz` in the future.

I didn't want to pass that configuration option through multiple function calls so I made a `ProxyHandler` handler struct, but I'm not very experienced with Go so I'm not sure if this is an idiomatic way to do this or if I'm clinging on to OOP where I shouldn't be. 